### PR TITLE
use ftc-events instead of frc-events

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       <p>Get the latest version of FTC Matches for your browser.</p>
       <p>Follow the instructions provided on the GitHub README </p>
       <a href="https://github.com/Team-7159-RoboRavens/FTC-matches" target="_blank" class="download-button">Download Now</a>
-      <h5><i>To use FTC Matches©, you MUST have an API Key from FIRST. If you dont, request one <a href="https://frc-events.firstinspires.org/services/api">here</a></i></h5>
+      <h5><i>To use FTC Matches©, you MUST have an API Key from FIRST. If you dont, request one <a href="https://ftc-events.firstinspires.org/services/api">here</a></i></h5>
       <h6>Please contact <a href="mailto:ftc-matches@roboravens.com">ftc-matches@roboravens.com</a> for any issues or questions</h6>
     </section>
     <footer>


### PR DESCRIPTION
Changes "request one *here*" link to point to `ftc-events.firstinspires.org` instead of `frc-events.firstinspires.org`.